### PR TITLE
Additional Setting For Content

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -2098,7 +2098,7 @@
         }
       ]
     },
-     {
+       {
       "type": "Product_extra_info",
       "name": "Product Extra Info",
       "settings": [
@@ -2106,6 +2106,33 @@
           "type": "richtext",
           "id": "extra_info_text",
           "label": "Product Extra Info Text"
+        },
+        {
+          "type": "range",
+          "id": "text_turncate_desk",
+          "min": 100,
+          "max": 1000,
+          "step": 10,
+          "unit": "px",
+          "label": "Display Content Length for Desktop",
+          "default": 100
+        },
+        {
+          "type": "range",
+          "id": "text_turncate_mobile",
+          "min": 100,
+          "max": 1000,
+          "step": 10,
+          "unit": "px",
+          "label": "Display Content Length for Mobile",
+          "default": 100,
+          "info": "Display content length for mobile starting from a screen size of 768 Pixels."
+        },
+        {
+          "type": "checkbox",
+          "id": "show_hide",
+          "label": "Show / Hide Turncate Words.",
+          "default": true
         }
       ]
     }

--- a/snippets/product-extra-info.liquid
+++ b/snippets/product-extra-info.liquid
@@ -1,3 +1,85 @@
-<div class="product_extra_info_text">
-    {{- block.settings.extra_info_text -}}
-</div> 
+<div class="product_extra_info_block">
+  {%- if block.settings.show_hide -%}
+    <div class="collection--description">
+      {% comment %} desktop {% endcomment %}
+      {% capture readmore_desktop %}
+        {%- assign value_Desk = block.settings.text_turncate_desk -%}
+            <div id="truncated">{{ block.settings.extra_info_text | truncate: value_Desk, "... <a class='read-more-collection' data-no-instant>Read More</a>" }}</div>
+            <div id="fullDescription" style="display: none">{{ block.settings.extra_info_text | append: " <a class='read-more-collection' data-no-instant>Read Less</a>" }}</div>
+        {% endcapture %}
+
+      {% comment %} mobile {% endcomment %}
+      {% capture readmore_mobile %}
+        {%- assign value_mobile = block.settings.text_turncate_mobile -%}
+            <div id="truncated_mobile">{{ block.settings.extra_info_text | truncate: value_mobile, "... <a class='read-more-collection_mobile' data-no-instant>Read More</a>" }}</div>
+            <div id="fullDescription_mobile" style="display: none">{{ block.settings.extra_info_text | append: " <a class='read-more-collection_mobile' data-no-instant>Read Less</a>" }}</div>
+        {% endcapture %}
+
+      <div class="desktop_content">{{ readmore_desktop }}</div>
+      <div class="mobile_content">{{ readmore_mobile }}</div>
+    </div>
+  {%- else -%}
+    <div class="fullDescriptions">{{ block.settings.extra_info_text }}</div>
+  {%- endif -%}
+</div>
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', function () {
+    //DESKTOP SCRIPT
+    document.querySelectorAll('.read-more-collection').forEach(function (element) {
+      element.addEventListener('click', function () {
+        var truncated = document.getElementById('truncated');
+        var fullDescription = document.getElementById('fullDescription');
+
+        if (truncated.style.display === 'none') {
+          truncated.style.display = 'block';
+          fullDescription.style.display = 'none';
+        } else {
+          truncated.style.display = 'none';
+          fullDescription.style.display = 'block';
+        }
+      });
+    });
+    // MOBILE SCRIPT
+    document.querySelectorAll('.read-more-collection_mobile').forEach(function (element) {
+        element.addEventListener('click', function () {
+          var truncated_mobile = document.getElementById('truncated_mobile');
+          var fullDescription_mobile = document.getElementById('fullDescription_mobile');
+
+          if (truncated_mobile.style.display === 'none') {
+            truncated_mobile.style.display = 'block';
+            fullDescription_mobile.style.display = 'none';
+          } else {
+            truncated_mobile.style.display = 'none';
+            fullDescription_mobile.style.display = 'block';
+          }
+        });
+      });
+
+  });
+</script>
+
+<style>
+  .product_extra_info_block p {
+    color: #000;
+    font-size: 16px;
+    margin-bottom: 0;
+  }
+  .read-more-collection,
+  .read-more-collection_mobile {
+    text-decoration: none;
+    color: red;
+    cursor: pointer !important;
+  }
+  .mobile_content {
+    display: none;
+  }
+  @media screen and (max-width: 768px) {
+    .mobile_content {
+      display: block;
+    }
+
+    .desktop_content {
+      display: none;
+    }
+  }
+</style>


### PR DESCRIPTION
Here's your chance to get creative; is there
anything else you could do for mobile/desktop modes that would show a super long 'Product Exta Info' in a better way for the
screen size?
